### PR TITLE
Improved Responsiveness by Reducing SSAPI Calls

### DIFF
--- a/src/accessories/alarm.js
+++ b/src/accessories/alarm.js
@@ -59,8 +59,7 @@ class SS3Alarm {
         this.service = this.accessory.getService(this.Service.SecuritySystem);
 
         this.service.getCharacteristic(this.Characteristic.SecuritySystemCurrentState)
-            .setProps({ validValues: this.VALID_CURRENT_STATE_VALUES })
-            .on('get', async callback => this.getCurrentState(callback));
+            .setProps({ validValues: this.VALID_CURRENT_STATE_VALUES });
         this.service.getCharacteristic(this.Characteristic.SecuritySystemTargetState)
             .setProps({ validValues: this.VALID_TARGET_STATE_VALUES })
             .on('set', async (state, callback) => this.setTargetState(state, callback));
@@ -77,18 +76,6 @@ class SS3Alarm {
         } catch (err) {
             this.log(`An error occurred while updating reachability for ${this.name}`);
             this.log(err);
-        }
-    }
-
-    async getCurrentState(callback) {
-        this.log('Getting current state...');
-        try {
-            let state = await this.simplisafe.getAlarmState();
-            let homekitState = this.CURRENT_SS3_TO_HOMEKIT[state];
-            this.log(`Current alarm state is: ${homekitState}`);
-            callback(null, homekitState);
-        } catch (err) {
-            callback(new Error(`An error occurred while getting the current alarm state: ${err}`));
         }
     }
 

--- a/src/accessories/alarm.js
+++ b/src/accessories/alarm.js
@@ -20,14 +20,6 @@ class SS3Alarm {
             'ALARM': Characteristic.SecuritySystemCurrentState.ALARM_TRIGGERED
         };
 
-        this.TARGET_SS3_TO_HOMEKIT = {
-            'OFF': Characteristic.SecuritySystemTargetState.DISARM,
-            'HOME': Characteristic.SecuritySystemTargetState.STAY_ARM,
-            'AWAY': Characteristic.SecuritySystemTargetState.AWAY_ARM,
-            'HOME_COUNT': Characteristic.SecuritySystemTargetState.STAY_ARM,
-            'AWAY_COUNT': Characteristic.SecuritySystemTargetState.AWAY_ARM
-        };
-
         this.TARGET_HOMEKIT_TO_SS3 = {
             [Characteristic.SecuritySystemTargetState.DISARM]: 'OFF',
             [Characteristic.SecuritySystemTargetState.STAY_ARM]: 'HOME',
@@ -71,7 +63,6 @@ class SS3Alarm {
             .on('get', async callback => this.getCurrentState(callback));
         this.service.getCharacteristic(this.Characteristic.SecuritySystemTargetState)
             .setProps({ validValues: this.VALID_TARGET_STATE_VALUES })
-            .on('get', async callback => this.getTargetState(callback))
             .on('set', async (state, callback) => this.setTargetState(state, callback));
 
         this.refreshState();
@@ -98,18 +89,6 @@ class SS3Alarm {
             callback(null, homekitState);
         } catch (err) {
             callback(new Error(`An error occurred while getting the current alarm state: ${err}`));
-        }
-    }
-
-    async getTargetState(callback) {
-        this.log('Getting target state...');
-        try {
-            let state = await this.simplisafe.getAlarmState();
-            let homekitState = this.TARGET_SS3_TO_HOMEKIT[state];
-            this.log(`Target alarm state is: ${homekitState}`);
-            callback(null, homekitState);
-        } catch (err) {
-            callback(new Error(`An error occurred while getting the target alarm state: ${err}`));
         }
     }
 

--- a/src/accessories/entrySensor.js
+++ b/src/accessories/entrySensor.js
@@ -29,8 +29,6 @@ class SS3EntrySensor {
             .setCharacteristic(this.Characteristic.SerialNumber, this.id);
 
         this.service = this.accessory.getService(this.Service.ContactSensor);
-        this.service.getCharacteristic(this.Characteristic.ContactSensorState)
-            .on('get', async callback => this.getState(callback));
 
         this.service.getCharacteristic(this.Characteristic.StatusLowBattery)
             .on('get', async callback => this.getBatteryStatus(callback));
@@ -74,23 +72,6 @@ class SS3EntrySensor {
         }
     }
 
-    async getState(callback) {
-        try {
-            let sensor = await this.getSensorInformation();
-
-            if (!sensor.status) {
-                throw new Error('Sensor response not understood');
-            }
-
-            let open = sensor.status.triggered;
-            let homekitState = open ? this.Characteristic.ContactSensorState.CONTACT_NOT_DETECTED : this.Characteristic.ContactSensorState.CONTACT_DETECTED;
-            callback(null, homekitState);
-
-        } catch (err) {
-            callback(new Error(`An error occurred while getting sensor state: ${err}`));
-        }
-    }
-
     async getBatteryStatus(callback) {
         try {
             let sensor = await this.getSensorInformation();
@@ -118,7 +99,7 @@ class SS3EntrySensor {
                         this.service.setCharacteristic(this.Characteristic.ContactSensorState, this.Characteristic.ContactSensorState.CONTACT_DETECTED);
                     }
                 }
-    
+
                 if (sensor.flags) {
                     if (sensor.flags.lowBattery) {
                         this.service.setCharacteristic(this.Characteristic.StatusLowBattery, this.Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW);


### PR DESCRIPTION
I have been thinking about this for a while. The motivation is that reaching SS servers (e.g. API calls) is slow for me (everyone?) so cutting them out would help with responsiveness, I think. 

So, **correct me if I'm wrong,** I think that these two calls on `'get'` for alarm current and target state can be removed. Because the alarm is using a socket connection the state should get updated (and appropriately "refreshed" using https://github.com/nzapponi/homebridge-simplisafe3/blob/f58bc779fedc73bd9f4d787aea3e3f0ff3ff9599/src/accessories/alarm.js#L178 ). I have been testing this and dont see any issues, alarm state looks right whether I set the alarm from SS app or via Home app. But please test this out / let me know if I'm mis-understanding something??

But, with those two calls removed, things are considerably faster for me, note the timestamps below (18 seconds total vs 6 seconds).

Before:
```
[1/28/2020, 5:43:57 PM] [Home Alarm] Getting current state...
getAlarmState
[1/28/2020, 5:43:57 PM] [Home Alarm] Getting target state...
getAlarmState
[1/28/2020, 5:43:58 PM] [Home Alarm] Current alarm state is: 3
[1/28/2020, 5:43:58 PM] [Home Alarm] Target alarm state is: 3
[1/28/2020, 5:44:07 PM] [Home Alarm] Setting target state to HOME, 0
setAlarmState
[1/28/2020, 5:44:10 PM] [Home Alarm] Updated alarm state: {"state":"HOME","stateUpdated":1580262250,"exitDelay":0}
[1/28/2020, 5:44:15 PM] [Home Alarm] Received new event from alarm: HOME_ARM
```

After:
```
[1/28/2020, 5:48:19 PM] [Home Alarm] Setting target state to HOME, 0
setAlarmState
[1/28/2020, 5:48:21 PM] [Home Alarm] Updated alarm state: {"state":"HOME","stateUpdated":1580262501,"exitDelay":0}
[1/28/2020, 5:48:25 PM] [Home Alarm] Received new event from alarm: HOME_ARM
```