### PR TITLE
Enhancement: Support for Config UI X Settings

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -1,0 +1,135 @@
+{
+	"pluginAlias": "homebridge-simplisafe3.SimpliSafe 3",
+	"pluginType": "platform",
+	"singular": true,
+	"schema": {
+		"type": "object",
+		"properties": {
+			"name": {
+				"title": "Name",
+				"type": "string",
+				"required": true,
+				"default": "Home Alarm",
+				"placeholder": "e.g. Home Alarm"
+			},
+			"auth": {
+				"title": "Authorization",
+				"type": "object",
+				"properties": {
+                    "username": {
+                        "title": "SimpliSafe Username",
+                        "type": "string",
+						"required": true
+                    },
+                    "password": {
+                        "title": "SimpliSafe Password",
+                        "type": "string",
+						"required": true
+                    }
+				}
+			},
+			"cameras": {
+				"title": " Cameras",
+				"type": "boolean",
+				"default": false,
+				"description": "Enable camera support."
+			},
+			"debug": {
+				"title": " Debug",
+				"type": "boolean"
+			},
+			"subscriptionId": {
+				"title": "Subscription ID",
+				"type": "string"
+			},
+			"sensorRefresh": {
+				"title": "Sensor Refresh Interval",
+				"type": "integer",
+				"default": 15
+			},
+			"persistAccessories": {
+				"title": " Persist Accessories",
+				"type": "boolean",
+				"default": true
+			},
+			"cameraOptions": {
+			    "title": "Optional Camera Settings",
+			    "type": "object",
+			    "condition": {
+                    "functionBody": "return (model.cameras)"
+                },
+			    "properties" : {
+			        "ffmpegPath": {
+			            "title": "ffmpeg Path",
+			            "type": "string",
+				        "placeholder": "/path/to/custom/ffmpeg",
+			            "condition": {
+                            "functionBody": "return (model.cameras)"
+                        }
+			        },
+			        "sourceOptions": {
+			            "title": "Source Options",
+			            "type": "string",
+			            "placeholder": "e.g. -vcodec h264_mmal",
+			            "condition": {
+                            "functionBody": "return (model.cameras)"
+                        }
+			        },
+			        "videoOptions": {
+			            "title": "Video Options",
+			            "type": "string",
+			            "placeholder": "e.g. -vcodec h264_omx -tune false",
+			            "condition": {
+                            "functionBody": "return (model.cameras)"
+                        }
+			        },
+			        "audioOptions": {
+			            "title": "Audio Options",
+			            "type": "string",
+			            "placeholder": "e.g. -ar 256k",
+			            "condition": {
+                            "functionBody": "return (model.cameras)"
+                        }
+			        }
+			    }
+			}
+		}
+	},
+	"layout": [
+	    {
+        "type": "fieldset",
+          "items": [
+            "name",
+            "auth.username",
+            "auth.password",
+            "cameras"
+          ]
+        },
+        {
+		"type": "fieldset",
+		"expandable": true,
+		"title": "Advanced Settings",
+		"items": [
+			"debug",
+			{
+				"key": "subscriptionId",
+				"description": "Add this parameter in case you have multiple protected locations or accounts with SimpliSafe. The subscriptionId can be found at the bottom of your base unit."
+			},
+			"sensorRefresh",
+			{
+				"key": "persistAccessories",
+				"description": "By default, the plugin won't remove old accessories from the Home app. This is to avoid caching issues causing you to lose all your scenes & automations configurations. If you do want to remove old accessories, set this to false."
+			},
+			{
+                "type": "fieldset",
+                "items": [
+                    "cameraOptions",
+                    "cameraOptions.ffmpegPath",
+                    "cameraOptions.sourceOptions",
+                    "cameraOptions.videoOptions",
+                    "cameraOptions.audioOptions"
+                ]
+            }
+		]
+	}]
+}

--- a/src/accessories/simplicam.js
+++ b/src/accessories/simplicam.js
@@ -432,7 +432,8 @@ class CameraSource {
                         }
 
                         if (this.cameraOptions.sourceOptions) {
-                            let options = this.cameraOptions.sourceOptions.split('-').filter(x => x).map(arg => '-' + arg).map(a => a.split(' ').filter(x => x));
+                            let options = (typeof this.cameraOptions.sourceOptions === 'string') ? this.cameraOptions.sourceOptions.split('-').filter(x => x).map(arg => '-' + arg).map(a => a.split(' ').filter(x => x))
+                                                                                                 : this.cameraOptions.sourceOptions; // support old config schema
                             for (let key in options) {
                                 let value = options[key];
                                 let existingArg = sourceArgs.find(arg => arg[0] === key);
@@ -449,7 +450,8 @@ class CameraSource {
                         }
 
                         if (this.cameraOptions.videoOptions) {
-                            let options = this.cameraOptions.videoOptions.split('-').filter(x => x).map(arg => '-' + arg).map(a => a.split(' ').filter(x => x));
+                            let options = (typeof this.cameraOptions.videoOptions === 'string') ? this.cameraOptions.videoOptions.split('-').filter(x => x).map(arg => '-' + arg).map(a => a.split(' ').filter(x => x))
+                                                                                                : this.cameraOptions.videoOptions; // support old config schema
                             for (let key in options) {
                                 let value = options[key];
                                 let existingArg = videoArgs.find(arg => arg[0] === key);
@@ -466,7 +468,8 @@ class CameraSource {
                         }
 
                         if (this.cameraOptions.audioOptions) {
-                            let options = this.cameraOptions.audioOptions.split('-').filter(x => x).map(arg => '-' + arg).map(a => a.split(' ').filter(x => x));
+                            let options = (typeof this.cameraOptions.audioOptions === 'string') ? this.cameraOptions.audioOptions.split('-').filter(x => x).map(arg => '-' + arg).map(a => a.split(' ').filter(x => x))
+                                                                                                : this.cameraOptions.audioOptions; // support old config schema
                             for (let key in options) {
                                 let value = options[key];
                                 let existingArg = audioArgs.find(arg => arg[0] === key);

--- a/src/accessories/simplicam.js
+++ b/src/accessories/simplicam.js
@@ -432,7 +432,7 @@ class CameraSource {
                         }
 
                         if (this.cameraOptions.sourceOptions) {
-                            let options = this.cameraOptions.sourceOptions;
+                            let options = this.cameraOptions.sourceOptions.split('-').filter(x => x).map(arg => '-' + arg).map(a => a.split(' ').filter(x => x));
                             for (let key in options) {
                                 let value = options[key];
                                 let existingArg = sourceArgs.find(arg => arg[0] === key);
@@ -449,7 +449,7 @@ class CameraSource {
                         }
 
                         if (this.cameraOptions.videoOptions) {
-                            let options = this.cameraOptions.videoOptions;
+                            let options = this.cameraOptions.videoOptions.split('-').filter(x => x).map(arg => '-' + arg).map(a => a.split(' ').filter(x => x));
                             for (let key in options) {
                                 let value = options[key];
                                 let existingArg = videoArgs.find(arg => arg[0] === key);
@@ -466,7 +466,7 @@ class CameraSource {
                         }
 
                         if (this.cameraOptions.audioOptions) {
-                            let options = this.cameraOptions.audioOptions;
+                            let options = this.cameraOptions.audioOptions.split('-').filter(x => x).map(arg => '-' + arg).map(a => a.split(' ').filter(x => x));
                             for (let key in options) {
                                 let value = options[key];
                                 let existingArg = audioArgs.find(arg => arg[0] === key);


### PR DESCRIPTION
Adds support for editing plugin settings using the popular [Config UI X plugin](https://github.com/oznu/homebridge-config-ui-x), see https://github.com/oznu/homebridge-config-ui-x/wiki/Developers:-Plugin-Settings-GUI .

This works well but the one catch is that currently the config accepts `cameraOptions` as a dictionary of arbitrary items (e.g. ffmpeg options) but there is no support for this in the json schema so I changed it to a single line of options specified the same way you would via command line e.g. "-vcodec h264_omx -tune false" and updated the simplicam code to work with this. I experimented with [yargs-parser](https://github.com/yargs/yargs-parser) but this was simpler.