### PR TITLE
Remove Unneeded mkdir For Internal Config File

### DIFF
--- a/src/simplisafe.js
+++ b/src/simplisafe.js
@@ -132,11 +132,6 @@ class SimpliSafe3 {
         } else {
             this.ssId = generateSimplisafeId();
 
-            // Ensure folder path exists
-            let pathComponents = internalConfigFile.split('/');
-            let folderPath = pathComponents.slice(0, pathComponents.length - 1).join('/');
-            fs.mkdirSync(folderPath, { recursive: true });
-
             try {
                 fs.writeFileSync(internalConfigFile, JSON.stringify({
                     ssId: this.ssId


### PR DESCRIPTION
Remnant from when file resided at `~/.homebridge/...`. No longer needed since the dir that will contain the file will be os.homedir which always exists.

Closes #73