### PR TITLE
Socket Connection Handler Updates

### DIFF
--- a/src/accessories/alarm.js
+++ b/src/accessories/alarm.js
@@ -205,8 +205,8 @@ class SS3Alarm {
                         case EVENT_TYPES.RECONNECT:
                             this.log('Alarm real time events re-connected.');
                             break;
-                        case EVENT_TYPES.RECONNECT_FAILED:
-                            this.log('Alarm real time events re-connect failed. Restarting');
+                        case EVENT_TYPES.CONNECTION_LOST:
+                            this.log('Alarm real time events connection lost. Attempting to restart...');
                             this.startListening();
                             break;
                         default:

--- a/src/accessories/alarm.js
+++ b/src/accessories/alarm.js
@@ -188,13 +188,14 @@ class SS3Alarm {
                         break;
                     case EVENT_TYPES.CONNECTION_LOST:
                         this.log('Alarm real time events connection lost. Attempting to restart...');
-                        this.startListening();
+                        setTimeout(async () => {
+                            await this.startListening();
+                        }, eventSubscribeRetryInterval);
                         break;
                 }
-                this.log('Alarm handler caught new event:', event);
                 if (this.service && data && data.sensorSerial == '' && data.sensorType == 0) {
-                    this.log('Alarm received new event:', event);
                     // alarm is initialzied
+                    this.log('Alarm received new event:', event);
                     switch (event) {
                         case EVENT_TYPES.ALARM_DISARM:
                         case EVENT_TYPES.ALARM_CANCEL:

--- a/src/accessories/alarm.js
+++ b/src/accessories/alarm.js
@@ -174,10 +174,9 @@ class SS3Alarm {
     }
 
     async startListening() {
-        this.log('Listening to alarm events...');
+        this.log('Alarm listening for real time events...');
         try {
             await this.simplisafe.subscribeToEvents(event => {
-                this.log(`Received new event from alarm: ${event}`);
                 if (this.service) {
                     switch (event) {
                         case EVENT_TYPES.ALARM_DISARM:
@@ -201,10 +200,17 @@ class SS3Alarm {
                             this.service.updateCharacteristic(this.Characteristic.SecuritySystemTargetState, this.Characteristic.SecuritySystemTargetState.AWAY_ARM);
                             break;
                         case EVENT_TYPES.DISCONNECT:
-                            this.log('Real time events disconnected.');
+                            this.log('Alarm real time events disconnected.');
+                            break;
+                        case EVENT_TYPES.RECONNECT:
+                            this.log('Alarm real time events re-connected.');
+                            break;
+                        case EVENT_TYPES.RECONNECT_FAILED:
+                            this.log(this.name + ' camera real time events re-connect failed. Restarting');
                             this.startListening();
                             break;
                         default:
+                            this.log(`Alarm ignoring unhandled event: ${event}`);
                             break;
                     }
                 }

--- a/src/accessories/alarm.js
+++ b/src/accessories/alarm.js
@@ -192,7 +192,7 @@ class SS3Alarm {
                         break;
                 }
                 if (this.service) {
-                    // this.log(`Alarm received new door lock event: ${event}`);
+                    // this.log(`Alarm received new event: ${event}`);
                     // alarm is initialzied
                     switch (event) {
                         case EVENT_TYPES.ALARM_DISARM:

--- a/src/accessories/alarm.js
+++ b/src/accessories/alarm.js
@@ -161,7 +161,7 @@ class SS3Alarm {
             this.nRetries = 0;
             callback(null);
         } catch (err) {
-            this.log(`Error while setting alarm state:`, err, 'nRetries:', this.nRetries);
+            this.log('Error while setting alarm state:', err, 'nRetries:', this.nRetries);
             if (err.type == 'SettingsInProgress' && this.nRetries < targetStateMaxRetries) {
                 this.nRetries++;
                 setTimeout(async () => {

--- a/src/accessories/alarm.js
+++ b/src/accessories/alarm.js
@@ -160,10 +160,11 @@ class SS3Alarm {
             this.nRetries = 0;
             callback(null);
         } catch (err) {
-            this.log(`Error while setting alarm state:`, err);
+            this.log(`Error while setting alarm state:`, err, 'nRetries:', this.nRetries);
             if (err.type == 'SettingsInProgress' && this.nRetries < targetStateMaxRetries) {
                 this.nRetries++;
                 setTimeout(async () => {
+                   // this.console.log('Retrying setTargetState...');
                     await this.setTargetState(homekitState, callback);
                 }, 1000); // wait 1  second and try again
             } else {
@@ -198,6 +199,9 @@ class SS3Alarm {
                         case EVENT_TYPES.AWAY_EXIT_DELAY:
                             this.service.updateCharacteristic(this.Characteristic.SecuritySystemTargetState, this.Characteristic.SecuritySystemTargetState.AWAY_ARM);
                             break;
+                        case EVENT_TYPES.CONNECTED:
+                            this.log('Alarm listening for real time events.');
+                            break;
                         case EVENT_TYPES.DISCONNECT:
                             this.log('Alarm real time events disconnected.');
                             break;
@@ -214,7 +218,7 @@ class SS3Alarm {
                     }
                 }
             });
-            this.log('Alarm listening for real time events...');
+            if (this.simplisafe.isSocketConnected()) this.log('Alarm listening for real time events.');
         } catch (err) {
             if (err instanceof RateLimitError) {
                 setTimeout(async () => {

--- a/src/accessories/alarm.js
+++ b/src/accessories/alarm.js
@@ -193,8 +193,8 @@ class SS3Alarm {
                         }, SOCKET_RETRY_INTERVAL);
                         break;
                 }
-                if (this.service && data && data.sensorSerial == '' && data.sensorType == 0) {
-                    // Alarm events
+                if (this.service && data && (data.sensorType == 0 || data.sensorType == 1 || data.sensorType == 2)) {
+                    // Alarm events (0 = app, 1 = keypad, 2 = fob)
                     this.log('Alarm received new event:', event);
                     switch (event) {
                         case EVENT_TYPES.ALARM_DISARM:

--- a/src/accessories/alarm.js
+++ b/src/accessories/alarm.js
@@ -196,7 +196,7 @@ class SS3Alarm {
                 }
                 if (this.service && data && (data.sensorType == 0 || data.sensorType == 1 || data.sensorType == 2)) {
                     // Alarm events (0 = app, 1 = keypad, 2 = fob)
-                    if (this.debug) this.log('Alarm received new event:', event);
+                    if (this.debug) this.log('Alarm received event:', event);
                     switch (event) {
                         case EVENT_TYPES.ALARM_DISARM:
                         case EVENT_TYPES.ALARM_CANCEL:

--- a/src/accessories/alarm.js
+++ b/src/accessories/alarm.js
@@ -164,7 +164,7 @@ class SS3Alarm {
             if (err.type == 'SettingsInProgress' && this.nRetries < targetStateMaxRetries) {
                 this.nRetries++;
                 setTimeout(async () => {
-                   // this.console.log('Retrying setTargetState...');
+                    this.console.log('Retrying setTargetState...');
                     await this.setTargetState(homekitState, callback);
                 }, 1000); // wait 1  second and try again
             } else {
@@ -192,7 +192,7 @@ class SS3Alarm {
                         break;
                 }
                 if (this.service) {
-                    // this.log(`Alarm received new event: ${event}`);
+                    this.log(`Alarm received new event: ${event}`);
                     // alarm is initialzied
                     switch (event) {
                         case EVENT_TYPES.ALARM_DISARM:

--- a/src/accessories/alarm.js
+++ b/src/accessories/alarm.js
@@ -206,7 +206,7 @@ class SS3Alarm {
                             this.log('Alarm real time events re-connected.');
                             break;
                         case EVENT_TYPES.RECONNECT_FAILED:
-                            this.log(this.name + ' camera real time events re-connect failed. Restarting');
+                            this.log('Alarm real time events re-connect failed. Restarting');
                             this.startListening();
                             break;
                         default:

--- a/src/accessories/alarm.js
+++ b/src/accessories/alarm.js
@@ -174,7 +174,6 @@ class SS3Alarm {
     }
 
     async startListening() {
-        this.log('Alarm listening for real time events...');
         try {
             await this.simplisafe.subscribeToEvents(event => {
                 if (this.service) {
@@ -215,6 +214,7 @@ class SS3Alarm {
                     }
                 }
             });
+            this.log('Alarm listening for real time events...');
         } catch (err) {
             if (err instanceof RateLimitError) {
                 setTimeout(async () => {

--- a/src/accessories/alarm.js
+++ b/src/accessories/alarm.js
@@ -192,6 +192,7 @@ class SS3Alarm {
                         break;
                 }
                 if (this.service) {
+                    // this.log(`Alarm received new door lock event: ${event}`);
                     // alarm is initialzied
                     switch (event) {
                         case EVENT_TYPES.ALARM_DISARM:

--- a/src/accessories/alarm.js
+++ b/src/accessories/alarm.js
@@ -177,7 +177,7 @@ class SS3Alarm {
     async startListening() {
         try {
             if (this.simplisafe.isSocketConnected()) this.log('Alarm now listening for real time events.');
-            await this.simplisafe.subscribeToEvents(event => {
+            await this.simplisafe.subscribeToEvents((event, data) => {
                 switch (event) {
                     // Socket events
                     case EVENT_TYPES.CONNECTED:
@@ -191,8 +191,9 @@ class SS3Alarm {
                         this.startListening();
                         break;
                 }
-                if (this.service) {
-                    this.log(`Alarm received new event: ${event}`);
+                this.log('Alarm handler caught new event:', event);
+                if (this.service && data && data.sensorSerial == '' && data.sensorType == 0) {
+                    this.log('Alarm received new event:', event);
                     // alarm is initialzied
                     switch (event) {
                         case EVENT_TYPES.ALARM_DISARM:

--- a/src/accessories/alarm.js
+++ b/src/accessories/alarm.js
@@ -194,7 +194,7 @@ class SS3Alarm {
                         break;
                 }
                 if (this.service && data && data.sensorSerial == '' && data.sensorType == 0) {
-                    // alarm is initialzied
+                    // Alarm events
                     this.log('Alarm received new event:', event);
                     switch (event) {
                         case EVENT_TYPES.ALARM_DISARM:

--- a/src/accessories/alarm.js
+++ b/src/accessories/alarm.js
@@ -176,18 +176,15 @@ class SS3Alarm {
 
     async startListening() {
         try {
-            if (this.simplisafe.isSocketConnected()) this.log('Alarm listening for real time events.');
+            if (this.simplisafe.isSocketConnected()) this.log('Alarm now listening for real time events.');
             await this.simplisafe.subscribeToEvents(event => {
                 switch (event) {
                     // Socket events
                     case EVENT_TYPES.CONNECTED:
-                        this.log('Alarm listening for real time events.');
+                        this.log('Alarm now listening for real time events.');
                         break;
                     case EVENT_TYPES.DISCONNECT:
                         this.log('Alarm real time events disconnected.');
-                        break;
-                    case EVENT_TYPES.RECONNECT:
-                        this.log('Alarm real time events re-connected.');
                         break;
                     case EVENT_TYPES.CONNECTION_LOST:
                         this.log('Alarm real time events connection lost. Attempting to restart...');

--- a/src/accessories/alarm.js
+++ b/src/accessories/alarm.js
@@ -187,7 +187,7 @@ class SS3Alarm {
                         this.log('Alarm real time events disconnected.');
                         break;
                     case EVENT_TYPES.CONNECTION_LOST:
-                        this.log('Alarm real time events connection lost. Attempting to restart...');
+                        this.log('Alarm real time events connection lost. Attempting to reconnect...');
                         setTimeout(async () => {
                             await this.startListening();
                         }, SOCKET_RETRY_INTERVAL);

--- a/src/accessories/alarm.js
+++ b/src/accessories/alarm.js
@@ -176,8 +176,8 @@ class SS3Alarm {
     }
 
     async startListening() {
+        if (this.debug && this.simplisafe.isSocketConnected()) this.log('Alarm now listening for real time events.');
         try {
-            if (this.debug && this.simplisafe.isSocketConnected()) this.log('Alarm now listening for real time events.');
             await this.simplisafe.subscribeToEvents((event, data) => {
                 switch (event) {
                     // Socket events

--- a/src/accessories/alarm.js
+++ b/src/accessories/alarm.js
@@ -1,9 +1,9 @@
 import {
     EVENT_TYPES,
-    RateLimitError
+    RateLimitError,
+    SOCKET_RETRY_INTERVAL
 } from '../simplisafe';
 
-const eventSubscribeRetryInterval = 10000; // ms
 const targetStateMaxRetries = 5;
 
 class SS3Alarm {
@@ -190,7 +190,7 @@ class SS3Alarm {
                         this.log('Alarm real time events connection lost. Attempting to restart...');
                         setTimeout(async () => {
                             await this.startListening();
-                        }, eventSubscribeRetryInterval);
+                        }, SOCKET_RETRY_INTERVAL);
                         break;
                 }
                 if (this.service && data && data.sensorSerial == '' && data.sensorType == 0) {
@@ -227,7 +227,7 @@ class SS3Alarm {
             if (err instanceof RateLimitError) {
                 setTimeout(async () => {
                     await this.startListening();
-                }, eventSubscribeRetryInterval);
+                }, SOCKET_RETRY_INTERVAL);
             }
         }
     }

--- a/src/accessories/alarm.js
+++ b/src/accessories/alarm.js
@@ -189,7 +189,7 @@ class SS3Alarm {
                         if (this.debug) this.log('Alarm real time events disconnected.');
                         break;
                     case EVENT_TYPES.CONNECTION_LOST:
-                        if (this.debug) this.log('Alarm real time events connection lost. Attempting to reconnect...');
+                        if (this.debug && this.nSocketConnectFailures == 0) this.log('Alarm real time events connection lost. Attempting to reconnect...');
                         setTimeout(async () => {
                             await this.startListening();
                         }, SOCKET_RETRY_INTERVAL);
@@ -227,12 +227,12 @@ class SS3Alarm {
             });
         } catch (err) {
             if (err instanceof RateLimitError) {
-                this.nSocketConnectFailures++;
-                let retryInterval = ((SOCKET_RETRY_INTERVAL / 1000) * 2) ** this.nSocketConnectFailures; //s
-                if (this.debug) this.log(`${this.name} alarm caught RateLimitError, waiting ${retryInterval}s to retry...`);
+                let retryInterval = (2 ** this.nSocketConnectFailures) * SOCKET_RETRY_INTERVAL;
+                if (this.debug) this.log(`${this.name} alarm caught RateLimitError, waiting ${retryInterval/1000}s to retry...`);
                 setTimeout(async () => {
                     await this.startListening();
-                }, retryInterval * 1000);
+                }, retryInterval);
+                this.nSocketConnectFailures++;
             }
         }
     }

--- a/src/accessories/alarm.js
+++ b/src/accessories/alarm.js
@@ -183,6 +183,7 @@ class SS3Alarm {
                     // Socket events
                     case EVENT_TYPES.CONNECTED:
                         if (this.debug) this.log('Alarm now listening for real time events.');
+                        this.nSocketConnectFailures = 0;
                         break;
                     case EVENT_TYPES.DISCONNECT:
                         if (this.debug) this.log('Alarm real time events disconnected.');
@@ -226,9 +227,12 @@ class SS3Alarm {
             });
         } catch (err) {
             if (err instanceof RateLimitError) {
+                this.nSocketConnectFailures++;
+                let retryInterval = ((SOCKET_RETRY_INTERVAL / 1000) * 2) ** this.nSocketConnectFailures; //s
+                if (this.debug) this.log(`${this.name} alarm caught RateLimitError, waiting ${retryInterval}s to retry...`);
                 setTimeout(async () => {
                     await this.startListening();
-                }, SOCKET_RETRY_INTERVAL);
+                }, retryInterval * 1000);
             }
         }
     }

--- a/src/accessories/doorLock.js
+++ b/src/accessories/doorLock.js
@@ -189,7 +189,7 @@ class SS3DoorLock {
                if (this.service) {
                    // Door lock events
                    if (data && data.sensorSerial && data.sensorSerial == this.id) {
-                       if (this.debug) this.log(`${this.name} lock received new door lock event: ${event}`);
+                       if (this.debug) this.log(`${this.name} lock received event: ${event}`);
                        switch (event) {
                            case EVENT_TYPES.DOORLOCK_UNLOCKED:
                                this.service.updateCharacteristic(this.Characteristic.LockCurrentState, this.Characteristic.LockCurrentState.UNSECURED);

--- a/src/accessories/doorLock.js
+++ b/src/accessories/doorLock.js
@@ -186,6 +186,7 @@ class SS3DoorLock {
                }
 
                if (this.service) {
+                   // Door lock events
                    if (data && data.sensorSerial && data.sensorSerial == this.id) {
                        this.log(`${this.name} lock received new door lock event: ${event}`);
                        switch (event) {

--- a/src/accessories/doorLock.js
+++ b/src/accessories/doorLock.js
@@ -167,17 +167,17 @@ class SS3DoorLock {
     }
 
     async startListening() {
+        if (this.debug && this.simplisafe.isSocketConnected()) this.log(`${this.name} lock now listening for real time events.`);
         try {
-           if (this.debug && this.simplisafe.isSocketConnected()) this.log(`${this.name} lock now listening for real time events.`);
            this.simplisafe.subscribeToEvents(async (event, data) => {
                switch (event) {
                   // Socket events
                    case EVENT_TYPES.CONNECTED:
                        if (this.debug) this.log(`${this.name} lock now listening for real time events.`);
-                     break;
+                       break;
                    case EVENT_TYPES.DISCONNECT:
                        if (this.debug) this.log(`${this.name} lock real time events disconnected.`);
-                     break;
+                       break;
                    case EVENT_TYPES.CONNECTION_LOST:
                        if (this.debug) this.log(`${this.name} lock real time events connection lost. Attempting to reconnect...`);
                        setTimeout(async () => {

--- a/src/accessories/doorLock.js
+++ b/src/accessories/doorLock.js
@@ -180,7 +180,9 @@ class SS3DoorLock {
                      break;
                    case EVENT_TYPES.CONNECTION_LOST:
                        this.log(`${this.name} lock real time events connection lost. Attempting to restart...`);
-                       this.startListening();
+                       setTimeout(async () => {
+                           await this.startListening();
+                       }, eventSubscribeRetryInterval);
                        break;
                }
 

--- a/src/accessories/doorLock.js
+++ b/src/accessories/doorLock.js
@@ -186,7 +186,7 @@ class SS3DoorLock {
 
                if (this.service) {
                    if (data && data.sensorSerial && data.sensorSerial == this.id) {
-                       // this.log(`${this.name} lock received new door lock event: ${event}`);
+                       this.log(`${this.name} lock received new door lock event: ${event}`);
                        switch (event) {
                            case EVENT_TYPES.DOORLOCK_UNLOCKED:
                                this.service.updateCharacteristic(this.Characteristic.LockCurrentState, this.Characteristic.LockCurrentState.UNSECURED);

--- a/src/accessories/doorLock.js
+++ b/src/accessories/doorLock.js
@@ -180,7 +180,7 @@ class SS3DoorLock {
                        if (this.debug) this.log(`${this.name} lock real time events disconnected.`);
                        break;
                    case EVENT_TYPES.CONNECTION_LOST:
-                       if (this.debug) this.log(`${this.name} lock real time events connection lost. Attempting to reconnect...`);
+                       if (this.debug && this.nSocketConnectFailures == 0) this.log(`${this.name} lock real time events connection lost. Attempting to reconnect...`);
                        setTimeout(async () => {
                            await this.startListening();
                        }, SOCKET_RETRY_INTERVAL);
@@ -222,12 +222,12 @@ class SS3DoorLock {
            });
         } catch (err) {
             if (err instanceof RateLimitError) {
-                this.nSocketConnectFailures++;
-                let retryInterval = ((SOCKET_RETRY_INTERVAL / 1000) * 2) ** this.nSocketConnectFailures; //s
-                if (this.debug) this.log(`${this.name} lock caught RateLimitError, waiting ${retryInterval}s to retry...`);
+                let retryInterval = (2 ** this.nSocketConnectFailures) * SOCKET_RETRY_INTERVAL;
+                if (this.debug) this.log(`${this.name} lock caught RateLimitError, waiting ${retryInterval/1000}s to retry...`);
                 setTimeout(async () => {
                     await this.startListening();
-                }, retryInterval * 1000);
+                }, retryInterval);
+                this.nSocketConnectFailures++;
             }
         }
     }

--- a/src/accessories/doorLock.js
+++ b/src/accessories/doorLock.js
@@ -186,8 +186,7 @@ class SS3DoorLock {
 
                if (this.service) {
                    if (data && data.sensorSerial && data.sensorSerial == this.id) {
-                       this.log(`Received new door lock event: ${event}`);
-
+                       // this.log(`${this.name} lock received new door lock event: ${event}`);
                        switch (event) {
                            case EVENT_TYPES.DOORLOCK_UNLOCKED:
                                this.service.updateCharacteristic(this.Characteristic.LockCurrentState, this.Characteristic.LockCurrentState.UNSECURED);

--- a/src/accessories/doorLock.js
+++ b/src/accessories/doorLock.js
@@ -178,7 +178,7 @@ class SS3DoorLock {
                        this.log(`${this.name} lock real time events disconnected.`);
                      break;
                    case EVENT_TYPES.CONNECTION_LOST:
-                       this.log(`${this.name} lock real time events connection lost. Attempting to restart...`);
+                       this.log(`${this.name} lock real time events connection lost. Attempting to reconnect...`);
                        setTimeout(async () => {
                            await this.startListening();
                        }, SOCKET_RETRY_INTERVAL);

--- a/src/accessories/doorLock.js
+++ b/src/accessories/doorLock.js
@@ -174,6 +174,7 @@ class SS3DoorLock {
                   // Socket events
                    case EVENT_TYPES.CONNECTED:
                        if (this.debug) this.log(`${this.name} lock now listening for real time events.`);
+                       this.nSocketConnectFailures = 0;
                        break;
                    case EVENT_TYPES.DISCONNECT:
                        if (this.debug) this.log(`${this.name} lock real time events disconnected.`);
@@ -221,10 +222,12 @@ class SS3DoorLock {
            });
         } catch (err) {
             if (err instanceof RateLimitError) {
-                this.log(`${this.name} lock caught RateLimitError, waiting to retry...`);
+                this.nSocketConnectFailures++;
+                let retryInterval = ((SOCKET_RETRY_INTERVAL / 1000) * 2) ** this.nSocketConnectFailures; //s
+                if (this.debug) this.log(`${this.name} lock caught RateLimitError, waiting ${retryInterval}s to retry...`);
                 setTimeout(async () => {
                     await this.startListening();
-                }, SOCKET_RETRY_INTERVAL);
+                }, retryInterval * 1000);
             }
         }
     }

--- a/src/accessories/doorLock.js
+++ b/src/accessories/doorLock.js
@@ -1,9 +1,8 @@
 import {
     EVENT_TYPES,
-    RateLimitError
+    RateLimitError,
+    SOCKET_RETRY_INTERVAL
 } from '../simplisafe';
-
-const eventSubscribeRetryInterval = 10000; // ms
 
 class SS3DoorLock {
 
@@ -182,7 +181,7 @@ class SS3DoorLock {
                        this.log(`${this.name} lock real time events connection lost. Attempting to restart...`);
                        setTimeout(async () => {
                            await this.startListening();
-                       }, eventSubscribeRetryInterval);
+                       }, SOCKET_RETRY_INTERVAL);
                        break;
                }
 
@@ -223,7 +222,7 @@ class SS3DoorLock {
                 this.log(`${this.name} lock caught RateLimitError, waiting to retry...`);
                 setTimeout(async () => {
                     await this.startListening();
-                }, eventSubscribeRetryInterval);
+                }, SOCKET_RETRY_INTERVAL);
             }
         }
     }

--- a/src/accessories/motionSensor.js
+++ b/src/accessories/motionSensor.js
@@ -117,7 +117,7 @@ class SS3MotionSensor {
                      this.log(`${this.name} motion sensor real time events disconnected.`);
                      break;
                   case EVENT_TYPES.CONNECTION_LOST:
-                     this.log(`${this.name} motion sensor real time events connection lost. Attempting to restart...`);
+                     this.log(`${this.name} motion sensor real time events connection lost. Attempting to reconnect...`);
                      setTimeout(async () => {
                          await this.startListening();
                      }, SOCKET_RETRY_INTERVAL);

--- a/src/accessories/motionSensor.js
+++ b/src/accessories/motionSensor.js
@@ -119,7 +119,7 @@ class SS3MotionSensor {
                      if (this.debug) this.log(`${this.name} motion sensor real time events disconnected.`);
                      break;
                   case EVENT_TYPES.CONNECTION_LOST:
-                     if (this.debug) this.log(`${this.name} motion sensor real time events connection lost. Attempting to reconnect...`);
+                     if (this.debug && this.nSocketConnectFailures == 0) this.log(`${this.name} motion sensor real time events connection lost. Attempting to reconnect...`);
                      setTimeout(async () => {
                          await this.startListening();
                      }, SOCKET_RETRY_INTERVAL);
@@ -144,12 +144,12 @@ class SS3MotionSensor {
             });
         } catch (err) {
             if (err instanceof RateLimitError) {
-                this.nSocketConnectFailures++;
-                let retryInterval = ((SOCKET_RETRY_INTERVAL / 1000) * 2) ** this.nSocketConnectFailures; //s
-                if (this.debug) this.log(`${this.name} motion sensor caught RateLimitError, waiting ${retryInterval}s to retry...`);
+                let retryInterval = (2 ** this.nSocketConnectFailures) * SOCKET_RETRY_INTERVAL;
+                if (this.debug) this.log(`${this.name} motion sensor caught RateLimitError, waiting ${retryInterval/1000}s to retry...`);
                 setTimeout(async () => {
                     await this.startListening();
-                }, retryInterval * 1000);
+                }, retryInterval);
+                this.nSocketConnectFailures++;
             }
         }
         this.simplisafe.subscribeToSensor(this.id, sensor => {

--- a/src/accessories/motionSensor.js
+++ b/src/accessories/motionSensor.js
@@ -125,6 +125,7 @@ class SS3MotionSensor {
                }
 
                if (data && this.id == data.sensorSerial) {
+                  // Motion sensor events
                   this.log(`${this.name} motion sensor received new event: ${event}`);
                   switch (event) {
                       case EVENT_TYPES.MOTION:

--- a/src/accessories/motionSensor.js
+++ b/src/accessories/motionSensor.js
@@ -119,6 +119,7 @@ class SS3MotionSensor {
                }
 
                if (data && this.id == data.sensorSerial) {
+                  this.log(`${this.name} motion sensor received new event: ${event}`);
                   switch (event) {
                       case EVENT_TYPES.MOTION:
                           this.accessory.getService(this.Service.MotionSensor).updateCharacteristic(this.Characteristic.MotionDetected, true);

--- a/src/accessories/motionSensor.js
+++ b/src/accessories/motionSensor.js
@@ -1,4 +1,9 @@
-import { EVENT_TYPES } from '../simplisafe';
+import {
+    EVENT_TYPES,
+    RateLimitError
+} from '../simplisafe';
+
+const eventSubscribeRetryInterval = 10000; // ms
 
 class SS3MotionSensor {
 

--- a/src/accessories/motionSensor.js
+++ b/src/accessories/motionSensor.js
@@ -119,7 +119,9 @@ class SS3MotionSensor {
                      break;
                   case EVENT_TYPES.CONNECTION_LOST:
                      this.log(`${this.name} motion sensor real time events connection lost. Attempting to restart...`);
-                     this.startListening();
+                     setTimeout(async () => {
+                         await this.startListening();
+                     }, eventSubscribeRetryInterval);
                   break;
                }
 

--- a/src/accessories/motionSensor.js
+++ b/src/accessories/motionSensor.js
@@ -127,7 +127,7 @@ class SS3MotionSensor {
 
                if (data && this.id == data.sensorSerial) {
                   // Motion sensor events
-                  if (this.debug) this.log(`${this.name} motion sensor received new event: ${event}`);
+                  if (this.debug) this.log(`${this.name} motion sensor received event: ${event}`);
                   switch (event) {
                       case EVENT_TYPES.MOTION:
                           this.accessory.getService(this.Service.MotionSensor).updateCharacteristic(this.Characteristic.MotionDetected, true);

--- a/src/accessories/motionSensor.js
+++ b/src/accessories/motionSensor.js
@@ -106,8 +106,8 @@ class SS3MotionSensor {
     }
 
     async startListening() {
+        if (this.debug && this.simplisafe.isSocketConnected()) this.log(`${this.name} motion sensor now listening for real time events.`);
         try {
-            if (this.debug && this.simplisafe.isSocketConnected()) this.log(`${this.name} motion sensor now listening for real time events.`);
             await this.simplisafe.subscribeToEvents((event, data) => {
                switch (event) {
                   // Socket events
@@ -122,7 +122,7 @@ class SS3MotionSensor {
                      setTimeout(async () => {
                          await this.startListening();
                      }, SOCKET_RETRY_INTERVAL);
-                  break;
+                     break;
                }
 
                if (data && this.id == data.sensorSerial) {

--- a/src/accessories/motionSensor.js
+++ b/src/accessories/motionSensor.js
@@ -113,6 +113,7 @@ class SS3MotionSensor {
                   // Socket events
                   case EVENT_TYPES.CONNECTED:
                      if (this.debug) this.log(`${this.name} motion sensor now listening for real time events.`);
+                     this.nSocketConnectFailures = 0;
                      break;
                   case EVENT_TYPES.DISCONNECT:
                      if (this.debug) this.log(`${this.name} motion sensor real time events disconnected.`);
@@ -143,10 +144,12 @@ class SS3MotionSensor {
             });
         } catch (err) {
             if (err instanceof RateLimitError) {
-                this.log(`${this.name} motion sensor caught RateLimitError, waiting to retry...`);
+                this.nSocketConnectFailures++;
+                let retryInterval = ((SOCKET_RETRY_INTERVAL / 1000) * 2) ** this.nSocketConnectFailures; //s
+                if (this.debug) this.log(`${this.name} motion sensor caught RateLimitError, waiting ${retryInterval}s to retry...`);
                 setTimeout(async () => {
                     await this.startListening();
-                }, SOCKET_RETRY_INTERVAL);
+                }, retryInterval * 1000);
             }
         }
         this.simplisafe.subscribeToSensor(this.id, sensor => {

--- a/src/accessories/motionSensor.js
+++ b/src/accessories/motionSensor.js
@@ -1,9 +1,8 @@
 import {
     EVENT_TYPES,
-    RateLimitError
+    RateLimitError,
+    SOCKET_RETRY_INTERVAL
 } from '../simplisafe';
-
-const eventSubscribeRetryInterval = 10000; // ms
 
 class SS3MotionSensor {
 
@@ -121,7 +120,7 @@ class SS3MotionSensor {
                      this.log(`${this.name} motion sensor real time events connection lost. Attempting to restart...`);
                      setTimeout(async () => {
                          await this.startListening();
-                     }, eventSubscribeRetryInterval);
+                     }, SOCKET_RETRY_INTERVAL);
                   break;
                }
 
@@ -145,7 +144,7 @@ class SS3MotionSensor {
                 this.log(`${this.name} motion sensor caught RateLimitError, waiting to retry...`);
                 setTimeout(async () => {
                     await this.startListening();
-                }, eventSubscribeRetryInterval);
+                }, SOCKET_RETRY_INTERVAL);
             }
         }
         this.simplisafe.subscribeToSensor(this.id, sensor => {

--- a/src/accessories/motionSensor.js
+++ b/src/accessories/motionSensor.js
@@ -109,38 +109,38 @@ class SS3MotionSensor {
         if (this.debug && this.simplisafe.isSocketConnected()) this.log(`${this.name} motion sensor now listening for real time events.`);
         try {
             await this.simplisafe.subscribeToEvents((event, data) => {
-               switch (event) {
-                  // Socket events
-                  case EVENT_TYPES.CONNECTED:
-                     if (this.debug) this.log(`${this.name} motion sensor now listening for real time events.`);
-                     this.nSocketConnectFailures = 0;
-                     break;
-                  case EVENT_TYPES.DISCONNECT:
-                     if (this.debug) this.log(`${this.name} motion sensor real time events disconnected.`);
-                     break;
-                  case EVENT_TYPES.CONNECTION_LOST:
-                     if (this.debug && this.nSocketConnectFailures == 0) this.log(`${this.name} motion sensor real time events connection lost. Attempting to reconnect...`);
-                     setTimeout(async () => {
-                         await this.startListening();
-                     }, SOCKET_RETRY_INTERVAL);
-                     break;
-               }
+                switch (event) {
+                    // Socket events
+                    case EVENT_TYPES.CONNECTED:
+                        if (this.debug) this.log(`${this.name} motion sensor now listening for real time events.`);
+                        this.nSocketConnectFailures = 0;
+                        break;
+                    case EVENT_TYPES.DISCONNECT:
+                        if (this.debug) this.log(`${this.name} motion sensor real time events disconnected.`);
+                        break;
+                    case EVENT_TYPES.CONNECTION_LOST:
+                        if (this.debug && this.nSocketConnectFailures == 0) this.log(`${this.name} motion sensor real time events connection lost. Attempting to reconnect...`);
+                        setTimeout(async () => {
+                            await this.startListening();
+                        }, SOCKET_RETRY_INTERVAL);
+                        break;
+                }
 
-               if (data && this.id == data.sensorSerial) {
-                  // Motion sensor events
-                  if (this.debug) this.log(`${this.name} motion sensor received event: ${event}`);
-                  switch (event) {
-                      case EVENT_TYPES.MOTION:
-                          this.accessory.getService(this.Service.MotionSensor).updateCharacteristic(this.Characteristic.MotionDetected, true);
-                          setTimeout(() => {
-                              this.accessory.getService(this.Service.MotionSensor).updateCharacteristic(this.Characteristic.MotionDetected, false);
-                          }, 10000);
-                          break;
-                      default:
-                          if (this.debug) this.log(`Motion sensor ${this.id} received unknown event '${event}' with data:`, data);
-                          break;
-                  }
-               }
+                if (data && this.id == data.sensorSerial) {
+                    // Motion sensor events
+                    if (this.debug) this.log(`${this.name} motion sensor received event: ${event}`);
+                    switch (event) {
+                        case EVENT_TYPES.MOTION:
+                            this.accessory.getService(this.Service.MotionSensor).updateCharacteristic(this.Characteristic.MotionDetected, true);
+                            setTimeout(() => {
+                                this.accessory.getService(this.Service.MotionSensor).updateCharacteristic(this.Characteristic.MotionDetected, false);
+                            }, 10000);
+                            break;
+                        default:
+                            if (this.debug) this.log(`Motion sensor ${this.id} received unknown event '${event}' with data:`, data);
+                            break;
+                    }
+                }
             });
         } catch (err) {
             if (err instanceof RateLimitError) {

--- a/src/accessories/simplicam.js
+++ b/src/accessories/simplicam.js
@@ -123,6 +123,7 @@ class SS3SimpliCam {
                   // Socket events
                    case EVENT_TYPES.CONNECTED:
                        if (this.debug) this.log(`${this.name} camera now listening for real time events.`);
+                       this.nSocketConnectFailures = 0;
                        break;
                    case EVENT_TYPES.DISCONNECT:
                        if (this.debug) this.log(`${this.name} camera real time events disconnected.`);
@@ -165,10 +166,12 @@ class SS3SimpliCam {
            });
         } catch (err) {
             if (err instanceof RateLimitError) {
-                this.log(`${this.name} camera caught RateLimitError, waiting to retry...`);
+                this.nSocketConnectFailures++;
+                let retryInterval = ((SOCKET_RETRY_INTERVAL / 1000) * 2) ** this.nSocketConnectFailures; //s
+                if (this.debug) this.log(`${this.name} camera caught RateLimitError, waiting ${retryInterval}s to retry...`);
                 setTimeout(async () => {
                     await this.startListening();
-                }, SOCKET_RETRY_INTERVAL);
+                }, retryInterval * 1000);
             }
         }
     }

--- a/src/accessories/simplicam.js
+++ b/src/accessories/simplicam.js
@@ -321,7 +321,7 @@ class CameraSource {
             callback(error);
         });
         ffmpegCmd.on('close', () => {
-            if (this.debug) this.log(`Closed ${this.cameraConfig.cameraSettings.cameraName} camera stream with image of ${imageBuffer.length}B`);
+            if (this.debug) this.log(`Closed ${this.cameraConfig.cameraSettings.cameraName} camera stream with image of ${Math.round(imageBuffer.length/1024)}kB`);
             callback(null, imageBuffer);
         });
     }

--- a/src/accessories/simplicam.js
+++ b/src/accessories/simplicam.js
@@ -132,7 +132,7 @@ class SS3SimpliCam {
                }
 
                if (this.accessory) {
-                  // this.log(`${this.name} camera received new door lock event: ${event}`);
+                  // this.log(`${this.name} camera received new event: ${event}`);
                   // camera is initialzied
                   let eventCameraId;
                   if (data && (data.sensorSerial || data.internal)) {

--- a/src/accessories/simplicam.js
+++ b/src/accessories/simplicam.js
@@ -115,6 +115,7 @@ class SS3SimpliCam {
 
     async startListening() {
         try {
+           if (this.simplisafe.isSocketConnected()) this.log(`${this.name} camera now listening for real time events.`);
            await this.simplisafe.subscribeToEvents((event, data) => {
                switch (event) {
                   // Socket events
@@ -123,9 +124,6 @@ class SS3SimpliCam {
                      break;
                    case EVENT_TYPES.DISCONNECT:
                        this.log(`${this.name} camera real time events disconnected.`);
-                     break;
-                   case EVENT_TYPES.RECONNECT:
-                       this.log(this.name + ' camera real time events re-connected.');
                      break;
                    case EVENT_TYPES.CONNECTION_LOST:
                        this.log(this.name + ' camera real time events connection lost. Attempting to restart...');
@@ -164,7 +162,6 @@ class SS3SimpliCam {
                   }
                }
            });
-           if (this.simplisafe.isSocketConnected()) this.log(`${this.name} camera now listening for real time events.`);
         } catch (err) {
             if (err instanceof RateLimitError) {
                 this.log(`${this.name} camera caught RateLimitError, waiting to retry...`);

--- a/src/accessories/simplicam.js
+++ b/src/accessories/simplicam.js
@@ -141,6 +141,9 @@ class SS3SimpliCam {
                            this.accessory.getService(this.Service.Doorbell).getCharacteristic(this.Characteristic.ProgrammableSwitchEvent).setValue(0);
                        }
                        break;
+                   case EVENT_TYPES.CONNECTED:
+                       this.log(`${this.name} camera now listening for real time events.`);
+                       break;
                    case EVENT_TYPES.DISCONNECT:
                        this.log(`${this.name} camera real time events disconnected.`);
                        break;
@@ -158,7 +161,7 @@ class SS3SimpliCam {
                        break;
                }
            });
-           this.log(`${this.name} camera now listening for real time events.`);
+           if (this.simplisafe.isSocketConnected()) this.log(`${this.name} camera now listening for real time events.`);
         } catch (err) {
             if (err instanceof RateLimitError) {
                 this.log(`${this.name} camera caught RateLimitError, waiting to retry...`);

--- a/src/accessories/simplicam.js
+++ b/src/accessories/simplicam.js
@@ -143,16 +143,22 @@ class SS3SimpliCam {
                        break;
                    case EVENT_TYPES.DISCONNECT:
                        this.log(`${this.name} camera real time events disconnected.`);
+                       break;
+                   case EVENT_TYPES.RECONNECT:
+                       this.log(this.name + ' camera real time events re-connected.');
+                       break;
+                   case EVENT_TYPES.RECONNECT_FAILED:
+                       this.log(this.name + ' camera real time events re-connect failed. Restarting');
                        this.startListening();
                        break;
                    default:
                        if (eventCameraId === this.id) {
-                           this.log(`${this.name} camera event received: ${event}`);
+                           this.log(`${this.name} camera ignoring unhandled event: ${event}`);
                        }
                        break;
                }
            });
-           this.log(`${this.name} camera now listening to alarm events.`);
+           this.log(`${this.name} camera now listening for real time events.`);
         } catch (err) {
             if (err instanceof RateLimitError) {
                 this.log(`${this.name} camera caught RateLimitError, waiting to retry...`);

--- a/src/accessories/simplicam.js
+++ b/src/accessories/simplicam.js
@@ -132,6 +132,7 @@ class SS3SimpliCam {
                }
 
                if (this.accessory) {
+                  // this.log(`${this.name} camera received new door lock event: ${event}`);
                   // camera is initialzied
                   let eventCameraId;
                   if (data && (data.sensorSerial || data.internal)) {

--- a/src/accessories/simplicam.js
+++ b/src/accessories/simplicam.js
@@ -126,7 +126,7 @@ class SS3SimpliCam {
                        this.log(`${this.name} camera real time events disconnected.`);
                      break;
                    case EVENT_TYPES.CONNECTION_LOST:
-                       this.log(this.name + ' camera real time events connection lost. Attempting to restart...');
+                       this.log(`${this.name} camera real time events connection lost. Attempting to restart...`);
                        this.startListening();
                        break;
                }

--- a/src/accessories/simplicam.js
+++ b/src/accessories/simplicam.js
@@ -143,7 +143,7 @@ class SS3SimpliCam {
 
                   if (eventCameraId == this.id) {
                      // Camera events
-                     if (this.debug) this.log(`${this.name} camera received new event: ${event}`);
+                     if (this.debug) this.log(`${this.name} camera received event: ${event}`);
                      switch (event) {
                          case EVENT_TYPES.CAMERA_MOTION:
                              this.accessory.getService(this.Service.MotionSensor).updateCharacteristic(this.Characteristic.MotionDetected, true);

--- a/src/accessories/simplicam.js
+++ b/src/accessories/simplicam.js
@@ -132,34 +132,30 @@ class SS3SimpliCam {
                }
 
                if (this.accessory) {
-                  // this.log(`${this.name} camera received new event: ${event}`);
+                  this.log(`${this.name} camera received new event: ${event}`);
                   // camera is initialzied
                   let eventCameraId;
                   if (data && (data.sensorSerial || data.internal)) {
                       eventCameraId = data.sensorSerial ? data.sensorSerial : data.internal.mainCamera;
                   }
 
-                  switch (event) {
-                      case EVENT_TYPES.CAMERA_MOTION:
-                          if (eventCameraId == this.id) {
-                              this.accessory.getService(this.Service.MotionSensor).updateCharacteristic(this.Characteristic.MotionDetected, true);
-                              this.cameraSource.motionIsTriggered = true;
-                              setTimeout(() => {
+                  if (eventCameraId == this.id) {
+                     switch (event) {
+                         case EVENT_TYPES.CAMERA_MOTION:
+                             this.accessory.getService(this.Service.MotionSensor).updateCharacteristic(this.Characteristic.MotionDetected, true);
+                             this.cameraSource.motionIsTriggered = true;
+                             setTimeout(() => {
                                   this.accessory.getService(this.Service.MotionSensor).updateCharacteristic(this.Characteristic.MotionDetected, false);
                                   this.cameraSource.motionIsTriggered = false;
-                              }, 5000);
-                          }
-                          break;
-                      case EVENT_TYPES.DOORBELL:
-                          if (eventCameraId == this.id) {
-                              this.accessory.getService(this.Service.Doorbell).getCharacteristic(this.Characteristic.ProgrammableSwitchEvent).setValue(0);
-                          }
-                          break;
-                      default:
-                          if (eventCameraId === this.id) {
-                              this.log(`${this.name} camera ignoring unhandled event: ${event}`);
-                          }
-                          break;
+                             }, 5000);
+                             break;
+                         case EVENT_TYPES.DOORBELL:
+                             this.accessory.getService(this.Service.Doorbell).getCharacteristic(this.Characteristic.ProgrammableSwitchEvent).setValue(0);
+                             break;
+                         default:
+                             this.log(`${this.name} camera ignoring unhandled event: ${event}`);
+                             break;
+                     }
                   }
                }
            });

--- a/src/accessories/simplicam.js
+++ b/src/accessories/simplicam.js
@@ -147,8 +147,8 @@ class SS3SimpliCam {
                    case EVENT_TYPES.RECONNECT:
                        this.log(this.name + ' camera real time events re-connected.');
                        break;
-                   case EVENT_TYPES.RECONNECT_FAILED:
-                       this.log(this.name + ' camera real time events re-connect failed. Restarting');
+                   case EVENT_TYPES.CONNECTION_LOST:
+                       this.log(this.name + ' camera real time events connection lost. Attempting to restart...');
                        this.startListening();
                        break;
                    default:

--- a/src/accessories/simplicam.js
+++ b/src/accessories/simplicam.js
@@ -126,7 +126,7 @@ class SS3SimpliCam {
                        this.log(`${this.name} camera real time events disconnected.`);
                      break;
                    case EVENT_TYPES.CONNECTION_LOST:
-                       this.log(`${this.name} camera real time events connection lost. Attempting to restart...`);
+                       this.log(`${this.name} camera real time events connection lost. Attempting to reconnect...`);
                        setTimeout(async () => {
                            await this.startListening();
                        }, SOCKET_RETRY_INTERVAL);

--- a/src/accessories/simplicam.js
+++ b/src/accessories/simplicam.js
@@ -132,7 +132,6 @@ class SS3SimpliCam {
                }
 
                if (this.accessory) {
-                  this.log(`${this.name} camera received new event: ${event}`);
                   // camera is initialzied
                   let eventCameraId;
                   if (data && (data.sensorSerial || data.internal)) {
@@ -140,6 +139,7 @@ class SS3SimpliCam {
                   }
 
                   if (eventCameraId == this.id) {
+                     this.log(`${this.name} camera received new event: ${event}`);
                      switch (event) {
                          case EVENT_TYPES.CAMERA_MOTION:
                              this.accessory.getService(this.Service.MotionSensor).updateCharacteristic(this.Characteristic.MotionDetected, true);

--- a/src/accessories/simplicam.js
+++ b/src/accessories/simplicam.js
@@ -129,7 +129,7 @@ class SS3SimpliCam {
                        if (this.debug) this.log(`${this.name} camera real time events disconnected.`);
                        break;
                    case EVENT_TYPES.CONNECTION_LOST:
-                       if (this.debug) this.log(`${this.name} camera real time events connection lost. Attempting to reconnect...`);
+                       if (this.debug && this.nSocketConnectFailures == 0) this.log(`${this.name} camera real time events connection lost. Attempting to reconnect...`);
                        setTimeout(async () => {
                            await this.startListening();
                        }, SOCKET_RETRY_INTERVAL);
@@ -166,12 +166,12 @@ class SS3SimpliCam {
            });
         } catch (err) {
             if (err instanceof RateLimitError) {
-                this.nSocketConnectFailures++;
-                let retryInterval = ((SOCKET_RETRY_INTERVAL / 1000) * 2) ** this.nSocketConnectFailures; //s
-                if (this.debug) this.log(`${this.name} camera caught RateLimitError, waiting ${retryInterval}s to retry...`);
+                let retryInterval = (2 ** this.nSocketConnectFailures) * SOCKET_RETRY_INTERVAL;
+                if (this.debug) this.log(`${this.name} camera caught RateLimitError, waiting ${retryInterval/1000}s to retry...`);
                 setTimeout(async () => {
                     await this.startListening();
-                }, retryInterval * 1000);
+                }, retryInterval);
+                this.nSocketConnectFailures++;
             }
         }
     }

--- a/src/accessories/simplicam.js
+++ b/src/accessories/simplicam.js
@@ -116,17 +116,17 @@ class SS3SimpliCam {
     }
 
     async startListening() {
+        if (this.debug && this.simplisafe.isSocketConnected()) this.log(`${this.name} camera now listening for real time events.`);
         try {
-           if (this.debug && this.simplisafe.isSocketConnected()) this.log(`${this.name} camera now listening for real time events.`);
            await this.simplisafe.subscribeToEvents((event, data) => {
                switch (event) {
                   // Socket events
                    case EVENT_TYPES.CONNECTED:
                        if (this.debug) this.log(`${this.name} camera now listening for real time events.`);
-                     break;
+                       break;
                    case EVENT_TYPES.DISCONNECT:
                        if (this.debug) this.log(`${this.name} camera real time events disconnected.`);
-                     break;
+                       break;
                    case EVENT_TYPES.CONNECTION_LOST:
                        if (this.debug) this.log(`${this.name} camera real time events connection lost. Attempting to reconnect...`);
                        setTimeout(async () => {

--- a/src/accessories/simplicam.js
+++ b/src/accessories/simplicam.js
@@ -118,52 +118,52 @@ class SS3SimpliCam {
     async startListening() {
         if (this.debug && this.simplisafe.isSocketConnected()) this.log(`${this.name} camera now listening for real time events.`);
         try {
-           await this.simplisafe.subscribeToEvents((event, data) => {
-               switch (event) {
-                  // Socket events
-                   case EVENT_TYPES.CONNECTED:
-                       if (this.debug) this.log(`${this.name} camera now listening for real time events.`);
-                       this.nSocketConnectFailures = 0;
-                       break;
-                   case EVENT_TYPES.DISCONNECT:
-                       if (this.debug) this.log(`${this.name} camera real time events disconnected.`);
-                       break;
-                   case EVENT_TYPES.CONNECTION_LOST:
-                       if (this.debug && this.nSocketConnectFailures == 0) this.log(`${this.name} camera real time events connection lost. Attempting to reconnect...`);
-                       setTimeout(async () => {
-                           await this.startListening();
-                       }, SOCKET_RETRY_INTERVAL);
-                       break;
-               }
+            await this.simplisafe.subscribeToEvents((event, data) => {
+                switch (event) {
+                    // Socket events
+                    case EVENT_TYPES.CONNECTED:
+                        if (this.debug) this.log(`${this.name} camera now listening for real time events.`);
+                        this.nSocketConnectFailures = 0;
+                        break;
+                    case EVENT_TYPES.DISCONNECT:
+                        if (this.debug) this.log(`${this.name} camera real time events disconnected.`);
+                        break;
+                    case EVENT_TYPES.CONNECTION_LOST:
+                        if (this.debug && this.nSocketConnectFailures == 0) this.log(`${this.name} camera real time events connection lost. Attempting to reconnect...`);
+                        setTimeout(async () => {
+                            await this.startListening();
+                        }, SOCKET_RETRY_INTERVAL);
+                        break;
+                }
 
-               if (this.accessory) {
-                  let eventCameraId;
-                  if (data && (data.sensorSerial || data.internal)) {
-                      eventCameraId = data.sensorSerial ? data.sensorSerial : data.internal.mainCamera;
-                  }
+                if (this.accessory) {
+                    let eventCameraId;
+                    if (data && (data.sensorSerial || data.internal)) {
+                        eventCameraId = data.sensorSerial ? data.sensorSerial : data.internal.mainCamera;
+                    }
 
-                  if (eventCameraId == this.id) {
-                     // Camera events
-                     if (this.debug) this.log(`${this.name} camera received event: ${event}`);
-                     switch (event) {
-                         case EVENT_TYPES.CAMERA_MOTION:
-                             this.accessory.getService(this.Service.MotionSensor).updateCharacteristic(this.Characteristic.MotionDetected, true);
-                             this.cameraSource.motionIsTriggered = true;
-                             setTimeout(() => {
-                                  this.accessory.getService(this.Service.MotionSensor).updateCharacteristic(this.Characteristic.MotionDetected, false);
-                                  this.cameraSource.motionIsTriggered = false;
-                             }, 5000);
-                             break;
-                         case EVENT_TYPES.DOORBELL:
-                             this.accessory.getService(this.Service.Doorbell).getCharacteristic(this.Characteristic.ProgrammableSwitchEvent).setValue(0);
-                             break;
-                         default:
-                             if (this.debug) this.log(`${this.name} camera ignoring unhandled event: ${event}`);
-                             break;
-                     }
-                  }
-               }
-           });
+                    if (eventCameraId == this.id) {
+                        // Camera events
+                        if (this.debug) this.log(`${this.name} camera received event: ${event}`);
+                        switch (event) {
+                            case EVENT_TYPES.CAMERA_MOTION:
+                                this.accessory.getService(this.Service.MotionSensor).updateCharacteristic(this.Characteristic.MotionDetected, true);
+                                this.cameraSource.motionIsTriggered = true;
+                                setTimeout(() => {
+                                    this.accessory.getService(this.Service.MotionSensor).updateCharacteristic(this.Characteristic.MotionDetected, false);
+                                    this.cameraSource.motionIsTriggered = false;
+                                }, 5000);
+                                break;
+                            case EVENT_TYPES.DOORBELL:
+                                this.accessory.getService(this.Service.Doorbell).getCharacteristic(this.Characteristic.ProgrammableSwitchEvent).setValue(0);
+                                break;
+                            default:
+                                if (this.debug) this.log(`${this.name} camera ignoring unhandled event: ${event}`);
+                                break;
+                        }
+                    }
+                }
+            });
         } catch (err) {
             if (err instanceof RateLimitError) {
                 let retryInterval = (2 ** this.nSocketConnectFailures) * SOCKET_RETRY_INTERVAL;
@@ -485,7 +485,7 @@ class CameraSource {
 
                         if (this.cameraOptions.sourceOptions) {
                             let options = (typeof this.cameraOptions.sourceOptions === 'string') ? this.cameraOptions.sourceOptions.split('-').filter(x => x).map(arg => '-' + arg).map(a => a.split(' ').filter(x => x))
-                                                                                                 : this.cameraOptions.sourceOptions; // support old config schema
+                                : this.cameraOptions.sourceOptions; // support old config schema
                             for (let key in options) {
                                 let value = options[key];
                                 let existingArg = sourceArgs.find(arg => arg[0] === key);
@@ -503,7 +503,7 @@ class CameraSource {
 
                         if (this.cameraOptions.videoOptions) {
                             let options = (typeof this.cameraOptions.videoOptions === 'string') ? this.cameraOptions.videoOptions.split('-').filter(x => x).map(arg => '-' + arg).map(a => a.split(' ').filter(x => x))
-                                                                                                : this.cameraOptions.videoOptions; // support old config schema
+                                : this.cameraOptions.videoOptions; // support old config schema
                             for (let key in options) {
                                 let value = options[key];
                                 let existingArg = videoArgs.find(arg => arg[0] === key);
@@ -521,7 +521,7 @@ class CameraSource {
 
                         if (this.cameraOptions.audioOptions) {
                             let options = (typeof this.cameraOptions.audioOptions === 'string') ? this.cameraOptions.audioOptions.split('-').filter(x => x).map(arg => '-' + arg).map(a => a.split(' ').filter(x => x))
-                                                                                                : this.cameraOptions.audioOptions; // support old config schema
+                                : this.cameraOptions.audioOptions; // support old config schema
                             for (let key in options) {
                                 let value = options[key];
                                 let existingArg = audioArgs.find(arg => arg[0] === key);
@@ -553,9 +553,9 @@ class CameraSource {
                     if (this.debug) this.log(`Start streaming video from ${this.cameraConfig.cameraSettings.cameraName}`);
 
                     if (this.debug) {
-                       cmd.stderr.on('data', data => {
-                           this.log(data.toString());
-                       });
+                        cmd.stderr.on('data', data => {
+                            this.log(data.toString());
+                        });
                     }
 
                     cmd.on('error', err => {

--- a/src/accessories/simplicam.js
+++ b/src/accessories/simplicam.js
@@ -382,7 +382,7 @@ class CameraSource {
         callback(response);
     }
 
-    handleStreamRequest = async (request) => {
+    async handleStreamRequest(request, callback) {
         if (this.simplisafe.isBlocked && Date.now() < this.simplisafe.nextAttempt) {
             return callback(new Error('Request blocked (rate limited)'));
         }
@@ -585,7 +585,7 @@ class CameraSource {
                 delete this.ongoingSessions[sessionIdentifier];
             }
         }
-    };
+    }
 
     createStreamControllers(maxStreams, options) {
         for (let i = 0; i < maxStreams; i++) {

--- a/src/accessories/simplicam.js
+++ b/src/accessories/simplicam.js
@@ -316,7 +316,7 @@ class CameraSource {
             callback(error);
         });
         ffmpegCmd.on('close', () => {
-            this.log(`Close ${this.cameraConfig.cameraSettings.cameraName} stream with image of length: ${imageBuffer.length}`);
+            this.log(`Closed ${this.cameraConfig.cameraSettings.cameraName} camera stream with image of ${imageBuffer.length}B`);
             callback(null, imageBuffer);
         });
     }

--- a/src/accessories/simplicam.js
+++ b/src/accessories/simplicam.js
@@ -134,13 +134,13 @@ class SS3SimpliCam {
                }
 
                if (this.accessory) {
-                  // camera is initialzied
                   let eventCameraId;
                   if (data && (data.sensorSerial || data.internal)) {
                       eventCameraId = data.sensorSerial ? data.sensorSerial : data.internal.mainCamera;
                   }
 
                   if (eventCameraId == this.id) {
+                     // Camera events
                      this.log(`${this.name} camera received new event: ${event}`);
                      switch (event) {
                          case EVENT_TYPES.CAMERA_MOTION:

--- a/src/accessories/simplicam.js
+++ b/src/accessories/simplicam.js
@@ -7,11 +7,11 @@ import ffmpeg from '@ffmpeg-installer/ffmpeg';
 
 import {
     EVENT_TYPES,
-    RateLimitError
+    RateLimitError,
+    SOCKET_RETRY_INTERVAL
 } from '../simplisafe';
 
 const dnsLookup = promisify(dns.lookup);
-const eventSubscribeRetryInterval = 10000; // ms
 
 class SS3SimpliCam {
 
@@ -129,7 +129,7 @@ class SS3SimpliCam {
                        this.log(`${this.name} camera real time events connection lost. Attempting to restart...`);
                        setTimeout(async () => {
                            await this.startListening();
-                       }, eventSubscribeRetryInterval);
+                       }, SOCKET_RETRY_INTERVAL);
                        break;
                }
 
@@ -166,7 +166,7 @@ class SS3SimpliCam {
                 this.log(`${this.name} camera caught RateLimitError, waiting to retry...`);
                 setTimeout(async () => {
                     await this.startListening();
-                }, eventSubscribeRetryInterval);
+                }, SOCKET_RETRY_INTERVAL);
             }
         }
     }

--- a/src/accessories/simplicam.js
+++ b/src/accessories/simplicam.js
@@ -127,7 +127,9 @@ class SS3SimpliCam {
                      break;
                    case EVENT_TYPES.CONNECTION_LOST:
                        this.log(`${this.name} camera real time events connection lost. Attempting to restart...`);
-                       this.startListening();
+                       setTimeout(async () => {
+                           await this.startListening();
+                       }, eventSubscribeRetryInterval);
                        break;
                }
 

--- a/src/simplisafe.js
+++ b/src/simplisafe.js
@@ -782,7 +782,7 @@ class SimpliSafe3 {
              });
 
              this.socket.on('disconnect', (reason) => {
-                 this.log('Socket disconnect reason: ', reason);
+                 this.log('Socket disconnect reason:', reason);
              });
         }
 

--- a/src/simplisafe.js
+++ b/src/simplisafe.js
@@ -755,12 +755,12 @@ class SimpliSafe3 {
 
             this.socket.on('connect_error', () => {
                 // this.log('Socket connect_error', err);
-                this.socket = null;
+                this.unsubscribeFromEvents();
             });
 
             this.socket.on('connect_timeout', () => {
                 // this.log('Socket connect_timeout');
-                this.socket = null;
+                this.unsubscribeFromEvents();
             });
 
             this.socket.on('error', (err) => {
@@ -777,6 +777,14 @@ class SimpliSafe3 {
                // this.log(`Socket reconnect_attempt ${attemptNumber}`);
             });
         }
+
+        this.socket.on('connect_error', err => {
+            callback(EVENT_TYPES.CONNECTION_LOST);
+        });
+
+        this.socket.on('connect_timeout', err => {
+            callback(EVENT_TYPES.CONNECTION_LOST);
+        });
 
         this.socket.on('error', err => {
             callback(EVENT_TYPES.CONNECTION_LOST);

--- a/src/simplisafe.js
+++ b/src/simplisafe.js
@@ -68,7 +68,6 @@ export const EVENT_TYPES = {
     DOORLOCK_ERROR: 'DOORLOCK_ERROR',
     CONNECTED: 'CONNECTED',
     DISCONNECT: 'DISCONNECT',
-    RECONNECT: 'RECONNECT',
     CONNECTION_LOST: 'CONNECTION_LOST'
 };
 export class RateLimitError extends Error {
@@ -760,6 +759,10 @@ class SimpliSafe3 {
            // this.log(`Socket reconnect_attempt ${attemptNumber}`);
         });
 
+        this.socket.on('reconnect', () => {
+            // this.log('Socket reconnect');
+        });
+
         this.socket.on('connect_error', (err) => {
             // this.log('Socket connect_error:', err);
             this.unsubscribeFromEvents();
@@ -782,11 +785,6 @@ class SimpliSafe3 {
             // this.log('Socket reconnect_failed');
             this.unsubscribeFromEvents();
             callback(EVENT_TYPES.CONNECTION_LOST);
-        });
-
-        this.socket.on('reconnect', () => {
-            // this.log('Socket reconnect');
-            callback(EVENT_TYPES.RECONNECT);
         });
 
         this.socket.on('disconnect', (reason) => {

--- a/src/simplisafe.js
+++ b/src/simplisafe.js
@@ -764,7 +764,7 @@ class SimpliSafe3 {
         });
 
         this.socket.on('connect_error', (err) => {
-            this.log('Socket connect_error:', err);
+            this.log(`Socket connect_error ${err.type}: ${err.message}`);
             this.unsubscribeFromEvents();
             callback(EVENT_TYPES.CONNECTION_LOST);
         });
@@ -776,7 +776,7 @@ class SimpliSafe3 {
         });
 
         this.socket.on('error', (err) => {
-            this.log('Socket error: ', err);
+            this.log(`Socket error ${err.type}: ${err.message}`);
             this.unsubscribeFromEvents();
             callback(EVENT_TYPES.CONNECTION_LOST);
         });

--- a/src/simplisafe.js
+++ b/src/simplisafe.js
@@ -66,6 +66,7 @@ export const EVENT_TYPES = {
     DOORLOCK_LOCKED: 'DOORLOCK_LOCKED',
     DOORLOCK_UNLOCKED: 'DOORLOCK_UNLOCKED',
     DOORLOCK_ERROR: 'DOORLOCK_ERROR',
+    CONNECTED: 'CONNECTED',
     DISCONNECT: 'DISCONNECT',
     RECONNECT: 'RECONNECT',
     CONNECTION_LOST: 'CONNECTION_LOST'
@@ -748,15 +749,16 @@ class SimpliSafe3 {
                 },
                 transports: ['websocket', 'polling']
             });
-
-            this.socket.on('connect', () => {
-                // this.log('Socket connect');
-            });
-
-            this.socket.on('reconnect_attempt', (attemptNumber) => {
-               // this.log(`Socket reconnect_attempt ${attemptNumber}`);
-            });
         }
+
+        this.socket.on('connect', () => {
+           // this.log('Socket connect');
+           callback(EVENT_TYPES.CONNECTED);
+        });
+
+        this.socket.on('reconnect_attempt', (attemptNumber) => {
+           // this.log(`Socket reconnect_attempt ${attemptNumber}`);
+        });
 
         this.socket.on('connect_error', (err) => {
             // this.log('Socket connect_error:', err);
@@ -783,6 +785,7 @@ class SimpliSafe3 {
         });
 
         this.socket.on('reconnect', () => {
+            // this.log('Socket reconnect');
             callback(EVENT_TYPES.RECONNECT);
         });
 

--- a/src/simplisafe.js
+++ b/src/simplisafe.js
@@ -70,6 +70,7 @@ export const EVENT_TYPES = {
     DISCONNECT: 'DISCONNECT',
     CONNECTION_LOST: 'CONNECTION_LOST'
 };
+
 export class RateLimitError extends Error {
     constructor(...params) {
         super(...params);
@@ -79,7 +80,9 @@ export class RateLimitError extends Error {
         }
         this.name = 'RateLimitError';
     }
-}
+};
+
+export const SOCKET_RETRY_INTERVAL = 1000; //ms
 
 const generateSimplisafeId = () => {
     const supportedCharacters = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnpqrstuvwxyz0123456789';

--- a/src/simplisafe.js
+++ b/src/simplisafe.js
@@ -756,19 +756,19 @@ class SimpliSafe3 {
              // for debugging, we only want one of these listeners
              if (this.debug) {
                 this.socket.on('connect', () => {
-                   this.log('Socket connect');
+                   this.log('Socket connected');
                 });
 
                 this.socket.on('reconnect_attempt', (attemptNumber) => {
-                   this.log(`Socket reconnect_attempt ${attemptNumber}`);
+                   this.log(`Socket reconnect_attempt #${attemptNumber}`);
                 });
 
                 this.socket.on('reconnect', () => {
-                    this.log('Socket reconnect');
+                    this.log('Socket reconnected');
                 });
 
                 this.socket.on('connect_error', (err) => {
-                    this.log(`Socket connect_error ${err.type}: ${err.message}`);
+                    this.log(`Socket connect_error${err.type && err.message ? ' ' + err.type + ': ' + err.message : ': ' + err}`);
                 });
 
                 this.socket.on('connect_timeout', () => {
@@ -776,7 +776,7 @@ class SimpliSafe3 {
                 });
 
                 this.socket.on('error', (err) => {
-                    this.log('Socket error', err);
+                    this.log(`Socket error${err.type && err.message ? ' ' + err.type + ': ' + err.message : ': ' + err}`);
                 });
 
                 this.socket.on('reconnect_failed', () => {

--- a/src/simplisafe.js
+++ b/src/simplisafe.js
@@ -847,7 +847,7 @@ class SimpliSafe3 {
                             .map(sub => sub.callback(sensor));
                     }
                 } catch (err) {
-                    if (!(err instanceof RateLimitError)) {
+                    if (!(err instanceof RateLimitError) && err.type !== 'SettingsInProgress') { // ignore rate limits & 409 errors
                         this.log(err);
                     }
                 }

--- a/src/simplisafe.js
+++ b/src/simplisafe.js
@@ -748,47 +748,66 @@ class SimpliSafe3 {
                 },
                 transports: ['websocket', 'polling']
             });
+
+             // for debugging, we only want one of these listeners
+             this.socket.on('connect', () => {
+                this.log('Socket connect');
+             });
+
+             this.socket.on('reconnect_attempt', (attemptNumber) => {
+                this.log(`Socket reconnect_attempt ${attemptNumber}`);
+             });
+
+             this.socket.on('reconnect', () => {
+                 this.log('Socket reconnect');
+             });
+
+             this.socket.on('connect_error', (err) => {
+                 this.log(`Socket connect_error ${err.type}: ${err.message}`);
+             });
+
+             this.socket.on('connect_timeout', () => {
+                 this.log('Socket connect_timeout');
+             });
+
+             this.socket.on('error', (err) => {
+                 this.log(`Socket error ${err.type}: ${err.message}`);
+             });
+
+             this.socket.on('reconnect_failed', () => {
+                 this.log('Socket reconnect_failed');
+             });
+
+             this.socket.on('disconnect', (reason) => {
+                 this.log('Socket disconnect reason: ', reason);
+             });
         }
 
         this.socket.on('connect', () => {
-           this.log('Socket connect');
            callback(EVENT_TYPES.CONNECTED);
         });
 
-        this.socket.on('reconnect_attempt', (attemptNumber) => {
-           this.log(`Socket reconnect_attempt ${attemptNumber}`);
-        });
-
-        this.socket.on('reconnect', () => {
-            this.log('Socket reconnect');
-        });
-
         this.socket.on('connect_error', (err) => {
-            this.log(`Socket connect_error ${err.type}: ${err.message}`);
             this.unsubscribeFromEvents();
             callback(EVENT_TYPES.CONNECTION_LOST);
         });
 
         this.socket.on('connect_timeout', () => {
-            this.log('Socket connect_timeout');
             this.unsubscribeFromEvents();
             callback(EVENT_TYPES.CONNECTION_LOST);
         });
 
         this.socket.on('error', (err) => {
-            this.log(`Socket error ${err.type}: ${err.message}`);
             this.unsubscribeFromEvents();
             callback(EVENT_TYPES.CONNECTION_LOST);
         });
 
         this.socket.on('reconnect_failed', () => {
-            this.log('Socket reconnect_failed');
             this.unsubscribeFromEvents();
             callback(EVENT_TYPES.CONNECTION_LOST);
         });
 
         this.socket.on('disconnect', (reason) => {
-            this.log('Socket disconnect reason: ', reason);
             callback(EVENT_TYPES.DISCONNECT);
         });
 

--- a/src/simplisafe.js
+++ b/src/simplisafe.js
@@ -776,7 +776,7 @@ class SimpliSafe3 {
                 });
 
                 this.socket.on('error', (err) => {
-                    this.log(`Socket error ${err.type}: ${err.message}`);
+                    this.log('Socket error', err);
                 });
 
                 this.socket.on('reconnect_failed', () => {

--- a/src/simplisafe.js
+++ b/src/simplisafe.js
@@ -804,7 +804,13 @@ class SimpliSafe3 {
         });
 
         this.socket.on('disconnect', (reason) => {
-            callback(EVENT_TYPES.DISCONNECT);
+            if (reason === 'io server disconnect') {
+               // the disconnection was initiated by the server, you need to reconnect manually
+               this.unsubscribeFromEvents();
+               callback(EVENT_TYPES.CONNECTION_LOST);
+            } else {
+               callback(EVENT_TYPES.DISCONNECT);
+            }
         });
 
         this.socket.on('event', _socketCallback);

--- a/src/simplisafe.js
+++ b/src/simplisafe.js
@@ -754,51 +754,43 @@ class SimpliSafe3 {
             });
 
              // for debugging, we only want one of these listeners
-             this.socket.on('connect', () => {
-                this.log('Socket connect');
-             });
+             if (this.debug) {
+                this.socket.on('connect', () => {
+                   this.log('Socket connect');
+                });
 
-             this.socket.on('reconnect_attempt', (attemptNumber) => {
-                this.log(`Socket reconnect_attempt ${attemptNumber}`);
-             });
+                this.socket.on('reconnect_attempt', (attemptNumber) => {
+                   this.log(`Socket reconnect_attempt ${attemptNumber}`);
+                });
 
-             this.socket.on('reconnect', () => {
-                 this.log('Socket reconnect');
-             });
+                this.socket.on('reconnect', () => {
+                    this.log('Socket reconnect');
+                });
 
-             this.socket.on('connect_error', (err) => {
-                 this.log(`Socket connect_error ${err.type}: ${err.message}`);
-             });
+                this.socket.on('connect_error', (err) => {
+                    this.log(`Socket connect_error ${err.type}: ${err.message}`);
+                });
 
-             this.socket.on('connect_timeout', () => {
-                 this.log('Socket connect_timeout');
-             });
+                this.socket.on('connect_timeout', () => {
+                    this.log('Socket connect_timeout');
+                });
 
-             this.socket.on('error', (err) => {
-                 this.log(`Socket error ${err.type}: ${err.message}`);
-             });
+                this.socket.on('error', (err) => {
+                    this.log(`Socket error ${err.type}: ${err.message}`);
+                });
 
-             this.socket.on('reconnect_failed', () => {
-                 this.log('Socket reconnect_failed');
-             });
+                this.socket.on('reconnect_failed', () => {
+                    this.log('Socket reconnect_failed');
+                });
 
-             this.socket.on('disconnect', (reason) => {
-                 this.log('Socket disconnect reason:', reason);
-             });
+                this.socket.on('disconnect', (reason) => {
+                    this.log('Socket disconnect reason:', reason);
+                });
+             }
         }
 
         this.socket.on('connect', () => {
            callback(EVENT_TYPES.CONNECTED);
-        });
-
-        this.socket.on('connect_error', (err) => {
-            this.unsubscribeFromEvents();
-            callback(EVENT_TYPES.CONNECTION_LOST);
-        });
-
-        this.socket.on('connect_timeout', () => {
-            this.unsubscribeFromEvents();
-            callback(EVENT_TYPES.CONNECTION_LOST);
         });
 
         this.socket.on('error', (err) => {

--- a/src/simplisafe.js
+++ b/src/simplisafe.js
@@ -753,44 +753,32 @@ class SimpliSafe3 {
                 // this.log('Socket connect');
             });
 
-            this.socket.on('connect_error', () => {
-                // this.log('Socket connect_error', err);
-                this.unsubscribeFromEvents();
-            });
-
-            this.socket.on('connect_timeout', () => {
-                // this.log('Socket connect_timeout');
-                this.unsubscribeFromEvents();
-            });
-
-            this.socket.on('error', (err) => {
-                // this.log('Socket error: ' + err);
-                this.unsubscribeFromEvents();
-            });
-
-            this.socket.on('reconnect_failed', () => {
-                // this.log('Socket reconnect_failed');
-                this.unsubscribeFromEvents();
-            });
-
             this.socket.on('reconnect_attempt', (attemptNumber) => {
                // this.log(`Socket reconnect_attempt ${attemptNumber}`);
             });
         }
 
-        this.socket.on('connect_error', err => {
+        this.socket.on('connect_error', (err) => {
+            // this.log('Socket connect_error:', err);
+            this.unsubscribeFromEvents();
             callback(EVENT_TYPES.CONNECTION_LOST);
         });
 
-        this.socket.on('connect_timeout', err => {
+        this.socket.on('connect_timeout', () => {
+            // this.log('Socket connect_timeout');
+            this.unsubscribeFromEvents();
             callback(EVENT_TYPES.CONNECTION_LOST);
         });
 
-        this.socket.on('error', err => {
+        this.socket.on('error', (err) => {
+            // this.log('Socket error: ', err);
+            this.unsubscribeFromEvents();
             callback(EVENT_TYPES.CONNECTION_LOST);
         });
 
         this.socket.on('reconnect_failed', () => {
+            // this.log('Socket reconnect_failed');
+            this.unsubscribeFromEvents();
             callback(EVENT_TYPES.CONNECTION_LOST);
         });
 
@@ -798,7 +786,8 @@ class SimpliSafe3 {
             callback(EVENT_TYPES.RECONNECT);
         });
 
-        this.socket.on('disconnect', reason => {
+        this.socket.on('disconnect', (reason) => {
+            // this.log('Socket disconnect reason: ', reason);
             callback(EVENT_TYPES.DISCONNECT);
         });
 
@@ -812,6 +801,7 @@ class SimpliSafe3 {
 
     unsubscribeFromEvents() {
         if (this.socket) {
+            this.socket.off();
             this.socket.close();
             this.socket = null;
         }

--- a/src/simplisafe.js
+++ b/src/simplisafe.js
@@ -751,44 +751,44 @@ class SimpliSafe3 {
         }
 
         this.socket.on('connect', () => {
-           // this.log('Socket connect');
+           this.log('Socket connect');
            callback(EVENT_TYPES.CONNECTED);
         });
 
         this.socket.on('reconnect_attempt', (attemptNumber) => {
-           // this.log(`Socket reconnect_attempt ${attemptNumber}`);
+           this.log(`Socket reconnect_attempt ${attemptNumber}`);
         });
 
         this.socket.on('reconnect', () => {
-            // this.log('Socket reconnect');
+            this.log('Socket reconnect');
         });
 
         this.socket.on('connect_error', (err) => {
-            // this.log('Socket connect_error:', err);
+            this.log('Socket connect_error:', err);
             this.unsubscribeFromEvents();
             callback(EVENT_TYPES.CONNECTION_LOST);
         });
 
         this.socket.on('connect_timeout', () => {
-            // this.log('Socket connect_timeout');
+            this.log('Socket connect_timeout');
             this.unsubscribeFromEvents();
             callback(EVENT_TYPES.CONNECTION_LOST);
         });
 
         this.socket.on('error', (err) => {
-            // this.log('Socket error: ', err);
+            this.log('Socket error: ', err);
             this.unsubscribeFromEvents();
             callback(EVENT_TYPES.CONNECTION_LOST);
         });
 
         this.socket.on('reconnect_failed', () => {
-            // this.log('Socket reconnect_failed');
+            this.log('Socket reconnect_failed');
             this.unsubscribeFromEvents();
             callback(EVENT_TYPES.CONNECTION_LOST);
         });
 
         this.socket.on('disconnect', (reason) => {
-            // this.log('Socket disconnect reason: ', reason);
+            this.log('Socket disconnect reason: ', reason);
             callback(EVENT_TYPES.DISCONNECT);
         });
 

--- a/src/simplisafe.js
+++ b/src/simplisafe.js
@@ -80,7 +80,7 @@ export class RateLimitError extends Error {
         }
         this.name = 'RateLimitError';
     }
-};
+}
 
 export const SOCKET_RETRY_INTERVAL = 1000; //ms
 
@@ -753,14 +753,14 @@ class SimpliSafe3 {
                 transports: ['websocket', 'polling']
             });
 
-             // for debugging, we only want one of these listeners
-             if (this.debug) {
+            // for debugging, we only want one of these listeners
+            if (this.debug) {
                 this.socket.on('connect', () => {
-                   this.log('Socket connected');
+                    this.log('Socket connected');
                 });
 
                 this.socket.on('reconnect_attempt', (attemptNumber) => {
-                   this.log(`Socket reconnect_attempt #${attemptNumber}`);
+                    this.log(`Socket reconnect_attempt #${attemptNumber}`);
                 });
 
                 this.socket.on('reconnect', () => {
@@ -786,16 +786,18 @@ class SimpliSafe3 {
                 this.socket.on('disconnect', (reason) => {
                     this.log('Socket disconnect reason:', reason);
                 });
-             }
+            }
         }
 
         this.socket.on('connect', () => {
-           callback(EVENT_TYPES.CONNECTED);
+            callback(EVENT_TYPES.CONNECTED);
         });
 
         this.socket.on('error', (err) => {
-            this.unsubscribeFromEvents();
-            callback(EVENT_TYPES.CONNECTION_LOST);
+            if (err) {
+                this.unsubscribeFromEvents();
+                callback(EVENT_TYPES.CONNECTION_LOST);
+            }
         });
 
         this.socket.on('reconnect_failed', () => {
@@ -805,11 +807,11 @@ class SimpliSafe3 {
 
         this.socket.on('disconnect', (reason) => {
             if (reason === 'io server disconnect') {
-               // the disconnection was initiated by the server, you need to reconnect manually
-               this.unsubscribeFromEvents();
-               callback(EVENT_TYPES.CONNECTION_LOST);
+                // the disconnection was initiated by the server, you need to reconnect manually
+                this.unsubscribeFromEvents();
+                callback(EVENT_TYPES.CONNECTION_LOST);
             } else {
-               callback(EVENT_TYPES.DISCONNECT);
+                callback(EVENT_TYPES.DISCONNECT);
             }
         });
 
@@ -845,7 +847,7 @@ class SimpliSafe3 {
                             .map(sub => sub.callback(sensor));
                     }
                 } catch (err) {
-                    if (!err instanceof RateLimitError) {
+                    if (!(err instanceof RateLimitError)) {
                         this.log(err);
                     }
                 }


### PR DESCRIPTION
Part of addressing #88

@nzapponi Please take a look at this. I think there were two separate issues, one was rate-limiting but the other was left un-addressed which is that the current code ends up creating multiple listening objects resulting in logs like:
```
[4/22/2020, 2:31:46 PM] [Home Alarm] Received new event from alarm: ALARM_DISARM
[4/22/2020, 2:31:46 PM] [Home Alarm] Received new event from alarm: ALARM_DISARM
[4/22/2020, 2:31:46 PM] [Home Alarm] Received new event from alarm: ALARM_DISARM
[4/22/2020, 2:31:46 PM] [Home Alarm] Received new event from alarm: ALARM_DISARM
[4/22/2020, 2:31:46 PM] [Home Alarm] Received new event from alarm: ALARM_DISARM
[4/22/2020, 2:31:46 PM] [Home Alarm] Received new event from alarm: ALARM_DISARM
[4/22/2020, 2:31:46 PM] [Home Alarm] Received new event from alarm: ALARM_DISARM
```

I think that is because we were passing `DISCONNECT` events from SS back to the alarm and the camera and [they call `startListening()` again](https://github.com/nzapponi/homebridge-simplisafe3/blob/e7b79f307e1ec1af9d771bba44a08d17644c8144/src/accessories/alarm.js#L205)  but that is actually unnecessary because the [.io protocol defaults to automatically reconnecting](https://socket.io/docs/client-api/#new-Manager-url-options). So as is the plugin would automatically _and manually_ re-connect, resulting in duplicate "listeners". In this PR I changed it to only call `startListening()` when re-connecting ultimately fails ([the `reconnect_failed` event is supposed to fire after the total attempts is tried](https://socket.io/docs/client-api/#Event-‘reconnect-failed’) but the default is infinity attempts). With these changes I now see logs that make more sense, like:
```
[4/23/2020, 7:52:55 AM] [Home Alarm] Living Room camera real time events disconnected.
[4/23/2020, 7:52:55 AM] [Home Alarm] Front Door camera real time events disconnected.
[4/23/2020, 7:52:57 AM] [Home Alarm] Received new event from alarm: RECONNECT
[4/23/2020, 7:52:57 AM] [Home Alarm] Living Room camera real time events re-connected.
[4/23/2020, 7:52:57 AM] [Home Alarm] Front Door camera real time events re-connected.
```

The only thing Im a little unsure of are the changes I made to simplisafe.js 764-774. I removed the built-in handlers for `'error'` and `'disconnect'` because I was thinking we dont need to destroy the socket connection on disconnects (Im less certain about removing the error handler). Incidentally I was wondering if those handlers should use your `unsubscribeFromEvents()` function.

Let me know your thoughts—cheers!