### PR TITLE
Lockout sensor refreshes for 30s after alarm state changes

### DIFF
--- a/src/simplisafe.js
+++ b/src/simplisafe.js
@@ -17,7 +17,7 @@ const internalConfigFileName = 'simplisafe3config.json';
 const mfaTimeout = 5 * 60 * 1000; // ms
 const rateLimitInitialInterval = 60000; // ms
 const rateLimitMaxInterval = 2 * 60 * 60 * 1000; // ms
-const sensorRefreshLockoutDuration = 30000; // ms
+const sensorRefreshLockoutDuration = 15000; // ms
 
 const ssApi = axios.create({
     baseURL: 'https://api.simplisafe.com/v1'
@@ -888,7 +888,7 @@ class SimpliSafe3 {
 
     handleSensorRefreshLockout() {
         if (!this.sensorRefreshLockoutEnabled) return;
-        // avoid "smart lock not responding" error with refresh lockout
+        // avoid "smart lock not responding" error with refresh lockout, see issue #134
         clearTimeout(this.sensorRefreshLockoutTimeout);
         this.sensorRefreshLockoutTimeout = setTimeout(() => {
             this.sensorRefreshLockoutTimeout = undefined;


### PR DESCRIPTION
Closes #134

@nzapponi When you have a second can you please take a look at this. Again, its to address this rather bizarre bug (#134) where smart locks make an audible alert "XXX smart lock not responding" every time you arm / disarm (it was driving me crazy). The solution as it is currently is to disable sensor refreshes for 30s after an alarm state change. Obviously it comes at the "price" of things like automations etc. not working for those 30s until refreshes resume, and it only is enabled if you have locks (line 606). Basically, does that all sound OK to you too?